### PR TITLE
Properly send flags and all events to callback

### DIFF
--- a/fswatch/fswatch.py
+++ b/fswatch/fswatch.py
@@ -11,16 +11,16 @@ class Monitor:
         self._callback = None
 
         def _callback_wrapper(events, event_num):
-            event = events[0]
-            self._callback(
-                event.path,
-                event.evt_time,
-                event.flags,
-                event.flags_num,
-                event_num,
-            )
+            for i in range(event_num):
+                flags_list = [events[i].flags[f_idx] for f_idx in range(events[i].flags_num)]
 
-        self._callback_wrapper = _callback_wrapper
+                self._callback(
+                    events[i].path,
+                    events[i].evt_time,
+                    flags_list,
+                )
+
+            self._callback_wrapper = _callback_wrapper
 
     def add_path(self, path: str):
         assert libfswatch.fsw_add_path(self.handle, path.encode()) == 0
@@ -61,7 +61,7 @@ def main():
     monitor.set_recursive()
     monitor.add_path("/tmp/test/")
 
-    def callback(path, evt_time, flags, flags_num, event_num):
+    def callback(path, evt_time, flags):
         print(path.decode())
 
     monitor.set_callback(callback)

--- a/fswatch/libfswatch.py
+++ b/fswatch/libfswatch.py
@@ -22,7 +22,7 @@ class fsw_cevent(ctypes.Structure):
     _fields_ = [
         ("path", ctypes.c_char_p),
         ("evt_time", ctypes.c_int),
-        ("flags", ctypes.c_void_p),
+        ("flags", ctypes.POINTER(ctypes.c_int32)),
         ("flags_num", ctypes.c_uint),
     ]
 


### PR DESCRIPTION
pyfswatch return to callback pointer to array of flags instead of list of flags set. Also it use only first event.

So, i changed it a bit and now it works as should be.

Signed-off-by: Anton Zelenov <antonz@sit.org>